### PR TITLE
feat: convert weather data source from Wunderground to WeatherLink v2 API

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,5 @@
 export DOCKER_DEFAULT_PLATFORM=linux/amd64
-export API="https://api.weather.com/v2/pws/observations/current"
-export STATION_ID="KCORAMAH7"
-export UNITS="e"
-export API_KEY=$(op read --cache "op://Parents/Wunderground/API Key")
+export API="https://api.weatherlink.com/v2"
+export KEY=$(op read --cache "op://Parents/WeatherLink/API/key")
+export API_SECRET=$(op read --cache "op://Parents/WeatherLink/API/secret")
 export RANDOM_SECRET="RANDOM_SECRET_VALUE2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,4 @@
 repos:
-  - repo: local
-    hooks:
-      - id: trufflehog
-        name: TruffleHog
-        description: Detect secrets in your data.
-        entry: trufflehog git file://. --since-commit HEAD --fail
-        language: golang
-        pass_filenames: false
-        stages: ["pre-commit", "pre-push"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Copy `.envrc` and populate the required env vars before running the binary direc
 ### Secrets & Config
 
 - **Production**: Vault Secrets Operator mounts credentials at `/mnt/secrets/{api,key,api_secret,rsec,fetch_buffer}`
-- **Local dev**: `readAPIConfig()` falls back to env vars when the secrets directory is absent
+- **Local dev**: if a secrets file is missing, `readAPIConfig()` falls back to the uppercase env var (`API`, `KEY`, `API_SECRET`); `readRandomSecret()` falls back to `RANDOM_SECRET`
 
 ### Embedded Assets
 
@@ -44,7 +44,7 @@ Copy `.envrc` and populate the required env vars before running the binary direc
 1. `GET /` → single handler renders `templates/index.html` with processed `Index` struct
 2. `getCachedWeatherData()` checks `weatherCache` — fetches from WeatherLink only if > 30 min since last call
 3. `discoverStationID()` calls `GET /stations` once (mutex-protected), then caches the station ID
-4. `fetchWeatherData()` calls `GET /current/{stationID}` and passes the raw response through `convertWLToLegacy()`, which extracts sensor type 45 / data structure 10 (ISS current conditions)
+4. `fetchWeatherData()` calls `GET /current/{stationID}` and passes the raw response through `convertWLToLegacy()`, which extracts ISS current conditions — sensor type 43/struct 23 (WeatherLink Console) or 45/struct 10 (WeatherLink Live); barometric pressure comes from sensor type 242/struct 19
 5. `GET /static/` serves embedded CSS and SVG logos
 
 ### Caching & Rate Limits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Binary serves on `:8080`.
 
 ### Local Development
 
-Copy `.envrc` and populate the required env vars before running the binary directly:
+Run locally with `direnv exec . ./pws` (the `.envrc` resolves secrets from 1Password via `op read --cache "op://Parents/WeatherLink/API/{key,secret}"`). Copy `.envrc` and populate the required env vars before running the binary directly:
 
 | Variable | Purpose |
 |---|---|
@@ -43,9 +43,17 @@ Copy `.envrc` and populate the required env vars before running the binary direc
 
 1. `GET /` → single handler renders `templates/index.html` with processed `Index` struct
 2. `getCachedWeatherData()` checks `weatherCache` — fetches from WeatherLink only if > 30 min since last call
-3. `discoverStationID()` calls `GET /stations` once (mutex-protected), then caches the station ID
-4. `fetchWeatherData()` calls `GET /current/{stationID}` and passes the raw response through `convertWLToLegacy()`, which extracts ISS current conditions — sensor type 43/struct 23 (WeatherLink Console) or 45/struct 10 (WeatherLink Live); barometric pressure comes from sensor type 242/struct 19
+3. `discoverStationID()` runs once at startup in `main()` (fails fast on bad key/network) and caches the ID via double-checked locking under `stationIDMutex`
+4. `fetchWeatherData()` calls `GET /current/{stationID}` and passes the raw response through `convertWLToLegacy()`, which extracts ISS current conditions — sensor type 43/struct 23 (WeatherLink Console) or 45/struct 10 (WeatherLink Live); barometric pressure comes from sensor type 242/struct 19; local report time is built from the `tz_offset` field in the sensor data
 5. `GET /static/` serves embedded CSS and SVG logos
+
+### Decisions & Gotchas
+
+- **Env var fallback** in `readAPIConfig()`/`readRandomSecret()` exists only so local dev doesn't need `/mnt/secrets/` files; production always reads the mounted files. Env var names are derived from the secret filename via `strings.ToUpper()` (`api_secret` → `API_SECRET`) — keep the two in sync.
+- **`convertWLToLegacy()` reshapes the WeatherLink v2 response into the internal `weatherObservation`** (a frozen copy of the old Wunderground shape).
+- **Wind speed is rounded to int** (`Imperial.WindSpeed` is `int`), so WeatherLink's fractional mph is rounded (e.g. 20.69 → 21).
+- **Single-station assumption**: `discoverStationID()` uses `Stations[0]`; an API key with multiple stations always picks the first.
+- **Sensor type 43/struct 23 is WeatherLink Console** — the original conversion only handled 45/struct 10 (WeatherLink Live) and failed against a Console station until both were supported.
 
 ### Caching & Rate Limits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+go build -o pws .        # build binary locally
+go test ./...            # run tests
+task build-container     # build Docker image (multi-stage → scratch, UPX-compressed)
+task run-container       # run container locally (sources .envrc / 1Password)
+```
+
+Binary serves on `:8080`.
+
+### Local Development
+
+Copy `.envrc` and populate the required env vars before running the binary directly:
+
+| Variable | Purpose |
+|---|---|
+| `API` | WeatherLink v2 base URL |
+| `KEY` | WeatherLink API key |
+| `API_SECRET` | WeatherLink API secret |
+| `RANDOM_SECRET` | Secret displayed in the UI |
+| `DEBUG` | Optional — enable verbose logging |
+| `FETCH_BUFFER_SECONDS` | Optional — cache buffer window (default 30s) |
+
+## Architecture
+
+**Single-file Go app** (`main.go`), no external dependencies — stdlib only.
+
+### Secrets & Config
+
+- **Production**: Vault Secrets Operator mounts credentials at `/mnt/secrets/{api,key,api_secret,rsec,fetch_buffer}`
+- **Local dev**: `readAPIConfig()` falls back to env vars when the secrets directory is absent
+
+### Embedded Assets
+
+`//go:embed` bundles `static/` (CSS, SVGs) and `templates/` (HTML) into the binary at compile time. Changes to those directories require a rebuild.
+
+### Request Flow
+
+1. `GET /` → single handler renders `templates/index.html` with processed `Index` struct
+2. `getCachedWeatherData()` checks `weatherCache` — fetches from WeatherLink only if > 30 min since last call
+3. `discoverStationID()` calls `GET /stations` once (mutex-protected), then caches the station ID
+4. `fetchWeatherData()` calls `GET /current/{stationID}` and passes the raw response through `convertWLToLegacy()`, which extracts sensor type 45 / data structure 10 (ISS current conditions)
+5. `GET /static/` serves embedded CSS and SVG logos
+
+### Caching & Rate Limits
+
+- `weatherCache` uses `sync.RWMutex` for thread safety
+- `shouldFetchNewData()` enforces a 30-minute minimum interval (≤ 2 API calls/hour)
+- `isDataFresh()` rejects observations older than 35 minutes; handler returns HTTP 503 if no valid cached data exists
+
+### CI/CD
+
+GitHub Actions (`release.yml`) builds with Docker Buildx for `linux/amd64` and pushes to `ghcr.io/methridge/ocp-pws` on semver tags (`v*.*.*`), tagging major, minor, patch, and `latest`.

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ to run in [OpenShift](https://www.openshift.com/). This also uses
 [Vault Secrets Operator](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/vso)
 to retrieve secrets.
 
-Reads the current conditions from Wunderground.com for my PWS.
+Reads the current conditions from [WeatherLink v2 API](https://weatherlink.github.io/v2-api/)
+for a Davis Instruments Personal Weather Station.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,57 @@
 # Personal Weather Station Current Data
 
-Modified version of my [CLI pws application](https://github.com/methridge/pws)
-to run in [OpenShift](https://www.openshift.com/). This also uses
-[HashiCorp Vault](https://www.vaultproject.io) with the
+Web app that displays current conditions from a Davis Instruments Personal Weather
+Station via the [WeatherLink v2 API](https://weatherlink.github.io/v2-api/). Designed
+to run in [OpenShift](https://www.openshift.com/) with
+[HashiCorp Vault](https://www.vaultproject.io) and the
 [Vault Secrets Operator](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/vso)
-to retrieve secrets.
+for secret management.
 
-Reads the current conditions from [WeatherLink v2 API](https://weatherlink.github.io/v2-api/)
-for a Davis Instruments Personal Weather Station.
+## Prerequisites
+
+- Davis Instruments PWS with a WeatherLink Console or WeatherLink Live data logger
+- WeatherLink v2 API key and secret (from [weatherlink.com](https://www.weatherlink.com))
+- Go 1.24+ (for local development)
+- [direnv](https://direnv.net/) + [1Password CLI](https://developer.1password.com/docs/cli/) (for the default `.envrc` setup)
+
+## Local Development
+
+Copy `.envrc` and populate the required variables, then run:
+
+```bash
+direnv exec . ./pws
+```
+
+The app serves on `http://localhost:8080`.
+
+### Environment Variables
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `API` | Yes | WeatherLink v2 base URL (`https://api.weatherlink.com/v2`) |
+| `KEY` | Yes | WeatherLink API key |
+| `API_SECRET` | Yes | WeatherLink API secret |
+| `RANDOM_SECRET` | Yes | Secret value displayed in the UI |
+| `DEBUG` | No | Set to any value to enable verbose logging |
+| `FETCH_BUFFER_SECONDS` | No | Cache buffer window in seconds (default: 30) |
+
+In production, these are mounted as files at `/mnt/secrets/{api,key,api_secret,rsec,fetch_buffer}`
+by the Vault Secrets Operator. The app falls back to env vars if the secret files are absent.
+
+## Build & Run
+
+```bash
+go build -o pws .          # build binary
+go test ./...              # run tests
+task build-container       # build Docker image (multi-stage → scratch, UPX-compressed)
+task run-container         # run container locally
+```
+
+The container image is built for `linux/amd64` and uses a `scratch` base with UPX compression
+for minimal size. The `task run-container` command loads credentials from `.envrc` via direnv
+or 1Password CLI.
+
+## CI/CD
+
+GitHub Actions (`release.yml`) builds and pushes to `ghcr.io/methridge/ocp-pws` on semver tags
+(`v*.*.*`), tagging major, minor, patch, and `latest`.

--- a/main.go
+++ b/main.go
@@ -22,36 +22,59 @@ var staticFiles embed.FS
 //go:embed templates/*
 var templateFiles embed.FS
 
+type weatherObservation struct {
+	StationID         string      `json:"stationID"`
+	ObsTimeUtc        time.Time   `json:"obsTimeUtc"`
+	ObsTimeLocal      string      `json:"obsTimeLocal"`
+	Neighborhood      string      `json:"neighborhood"`
+	SoftwareType      string      `json:"softwareType"`
+	Country           string      `json:"country"`
+	SolarRadiation    float64     `json:"solarRadiation"`
+	Lon               float64     `json:"lon"`
+	RealtimeFrequency interface{} `json:"realtimeFrequency"`
+	Epoch             int         `json:"epoch"`
+	Lat               float64     `json:"lat"`
+	Uv                float64     `json:"uv"`
+	Winddir           int         `json:"winddir"`
+	Humidity          int         `json:"humidity"`
+	QcStatus          int         `json:"qcStatus"`
+	Imperial          struct {
+		Temp        int     `json:"temp"`
+		HeatIndex   int     `json:"heatIndex"`
+		Dewpt       int     `json:"dewpt"`
+		WindChill   int     `json:"windChill"`
+		WindSpeed   int     `json:"windSpeed"`
+		WindGust    int     `json:"windGust"`
+		Pressure    float64 `json:"pressure"`
+		PrecipRate  float64 `json:"precipRate"`
+		PrecipTotal float64 `json:"precipTotal"`
+		Elev        int     `json:"elev"`
+	} `json:"imperial"`
+}
+
 type weatherCurrent struct {
-	Observations []struct {
-		StationID         string      `json:"stationID"`
-		ObsTimeUtc        time.Time   `json:"obsTimeUtc"`
-		ObsTimeLocal      string      `json:"obsTimeLocal"`
-		Neighborhood      string      `json:"neighborhood"`
-		SoftwareType      string      `json:"softwareType"`
-		Country           string      `json:"country"`
-		SolarRadiation    float64     `json:"solarRadiation"`
-		Lon               float64     `json:"lon"`
-		RealtimeFrequency interface{} `json:"realtimeFrequency"`
-		Epoch             int         `json:"epoch"`
-		Lat               float64     `json:"lat"`
-		Uv                float64     `json:"uv"`
-		Winddir           int         `json:"winddir"`
-		Humidity          int         `json:"humidity"`
-		QcStatus          int         `json:"qcStatus"`
-		Imperial          struct {
-			Temp        int     `json:"temp"`
-			HeatIndex   int     `json:"heatIndex"`
-			Dewpt       int     `json:"dewpt"`
-			WindChill   int     `json:"windChill"`
-			WindSpeed   int     `json:"windSpeed"`
-			WindGust    int     `json:"windGust"`
-			Pressure    float64 `json:"pressure"`
-			PrecipRate  float64 `json:"precipRate"`
-			PrecipTotal float64 `json:"precipTotal"`
-			Elev        int     `json:"elev"`
-		} `json:"imperial"`
-	} `json:"observations"`
+	Observations []weatherObservation `json:"observations"`
+}
+
+type wlStationsResponse struct {
+	Stations []struct {
+		StationID     int64  `json:"station_id"`
+		StationIDUUID string `json:"station_id_uuid"`
+		StationName   string `json:"station_name"`
+	} `json:"stations"`
+}
+
+type wlCurrentResponse struct {
+	StationID   int64      `json:"station_id"`
+	Sensors     []wlSensor `json:"sensors"`
+	GeneratedAt int64      `json:"generated_at"`
+}
+
+type wlSensor struct {
+	LSID              int64                    `json:"lsid"`
+	SensorType        int                      `json:"sensor_type"`
+	DataStructureType int                      `json:"data_structure_type"`
+	Data              []map[string]interface{} `json:"data"`
 }
 
 // Index holds fields displayed on the index.html template
@@ -77,7 +100,11 @@ var httpClient = &http.Client{
 }
 
 // Global variables for API configuration read at startup
-var api, sid, units, key string
+var api, key, apiSecret string
+
+// Cached station ID
+var cachedStationID int64
+var stationIDMutex sync.RWMutex
 
 // Configurable buffer time (default 30 seconds)
 var fetchBufferSeconds = 30
@@ -94,17 +121,22 @@ var cache = &weatherCache{}
 
 func readAPIConfig() error {
 	secretFiles := map[string]*string{
-		"api":   &api,
-		"sid":   &sid,
-		"units": &units,
-		"key":   &key,
+		"api":        &api,
+		"key":        &key,
+		"api_secret": &apiSecret,
 	}
 
 	for fileName, envVar := range secretFiles {
 		filePath := fmt.Sprintf("/mnt/secrets/%s", fileName)
 		content, err := os.ReadFile(filePath)
 		if err != nil {
-			return fmt.Errorf("failed to read secret file %s: %v", fileName, err)
+			envKey := strings.ToUpper(fileName)
+			if val := os.Getenv(envKey); val != "" {
+				*envVar = val
+				log.Printf("Using %s from environment variable", envKey)
+				continue
+			}
+			return fmt.Errorf("failed to read secret file %s and env var %s is not set", fileName, envKey)
 		}
 		*envVar = strings.TrimSpace(string(content))
 	}
@@ -134,6 +166,9 @@ func readAPIConfig() error {
 func readRandomSecret() (string, error) {
 	content, err := os.ReadFile("/mnt/secrets/rsec")
 	if err != nil {
+		if val := os.Getenv("RANDOM_SECRET"); val != "" {
+			return val, nil
+		}
 		return "", fmt.Errorf("failed to read random_secret file: %v", err)
 	}
 	return strings.TrimSpace(string(content)), nil
@@ -174,23 +209,155 @@ func shouldFetchNewData(t time.Time) bool {
 	return true
 }
 
-// fetchWeatherData fetches weather data from the API and caches it
-func fetchWeatherData() (weatherCurrent, error) {
-	url := fmt.Sprintf("%s?stationId=%s&format=json&units=%s&apiKey=%s",
-		api,
-		sid,
-		units,
-		key,
-	)
+// discoverStationID fetches and caches the station ID from the WeatherLink API
+func discoverStationID() (int64, error) {
+	stationIDMutex.RLock()
+	if cachedStationID != 0 {
+		defer stationIDMutex.RUnlock()
+		return cachedStationID, nil
+	}
+	stationIDMutex.RUnlock()
 
-	log.Printf("Making API request to: %s", strings.Replace(url, key, "***REDACTED***", 1))
+	url := fmt.Sprintf("%s/stations?api-key=%s", api, key)
+
+	log.Printf("Discovering station ID from: %s", strings.Replace(url, key, "***REDACTED***", 1))
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("error creating stations request: %v", err)
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Api-Secret", apiSecret)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("error fetching stations: %v", err)
+	}
+	defer resp.Body.Close()
+
+	log.Printf("Stations API response status: %d %s", resp.StatusCode, resp.Status)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("stations API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("error reading stations response: %v", err)
+	}
+
+	var stationsResp wlStationsResponse
+	if err := json.Unmarshal(body, &stationsResp); err != nil {
+		return 0, fmt.Errorf("error parsing stations response: %v", err)
+	}
+
+	if len(stationsResp.Stations) == 0 {
+		return 0, fmt.Errorf("no stations found for this API key")
+	}
+
+	stationIDMutex.Lock()
+	cachedStationID = stationsResp.Stations[0].StationID
+	stationIDMutex.Unlock()
+
+	log.Printf("Discovered station ID: %d (%s)", stationsResp.Stations[0].StationID, stationsResp.Stations[0].StationName)
+
+	return cachedStationID, nil
+}
+
+// isISSCurrentConditions returns true for sensors that carry ISS current conditions.
+// Supported combinations:
+//   - type 45 / struct 10: WeatherLink Live ISS
+//   - type 43 / struct 23: WeatherLink Console ISS
+func isISSCurrentConditions(s wlSensor) bool {
+	return (s.SensorType == 45 && s.DataStructureType == 10) ||
+		(s.SensorType == 43 && s.DataStructureType == 23)
+}
+
+// convertWLToLegacy converts WeatherLink v2 response to legacy weatherCurrent format
+func convertWLToLegacy(wl wlCurrentResponse) (weatherCurrent, error) {
+	var issData map[string]interface{}
+	var baroData map[string]interface{}
+	for _, sensor := range wl.Sensors {
+		if isISSCurrentConditions(sensor) && len(sensor.Data) > 0 {
+			issData = sensor.Data[0]
+		}
+		// sensor_type 242 / data_structure_type 19 = barometric pressure sensor
+		if sensor.SensorType == 242 && sensor.DataStructureType == 19 && len(sensor.Data) > 0 {
+			baroData = sensor.Data[0]
+		}
+	}
+
+	if issData == nil {
+		return weatherCurrent{}, fmt.Errorf("no ISS current conditions data found (supported: sensor_type 45/struct 10 or 43/struct 23)")
+	}
+
+	ts, ok := issData["ts"].(float64)
+	if !ok {
+		return weatherCurrent{}, fmt.Errorf("missing or invalid timestamp in sensor data")
+	}
+	obsTime := time.Unix(int64(ts), 0).UTC()
+	obsTimeLocal := obsTime.Format("2006-01-02 15:04:05 MST")
+
+	extractFloat := func(key string) float64 {
+		if v, ok := issData[key]; ok && v != nil {
+			if f, ok := v.(float64); ok {
+				return f
+			}
+		}
+		return 0
+	}
+
+	extractInt := func(key string) int {
+		return int(extractFloat(key))
+	}
+
+	observation := weatherObservation{
+		StationID:      fmt.Sprintf("%d", wl.StationID),
+		ObsTimeUtc:     obsTime,
+		ObsTimeLocal:   obsTimeLocal,
+		Winddir:        extractInt("wind_dir_last"),
+		Humidity:       extractInt("hum"),
+		Uv:             extractFloat("uv_index"),
+		SolarRadiation: extractFloat("solar_rad"),
+		Epoch:          int(ts),
+	}
+
+	observation.Imperial.Temp = extractInt("temp")
+	observation.Imperial.HeatIndex = extractInt("heat_index")
+	observation.Imperial.Dewpt = extractInt("dew_point")
+	observation.Imperial.WindChill = extractInt("wind_chill")
+	observation.Imperial.WindSpeed = extractInt("wind_speed_last")
+	observation.Imperial.WindGust = extractInt("wind_speed_hi_last_2_min")
+
+	if baroData != nil {
+		if v, ok := baroData["bar_sea_level"]; ok && v != nil {
+			if f, ok := v.(float64); ok {
+				observation.Imperial.Pressure = f
+			}
+		}
+	}
+
+	return weatherCurrent{Observations: []weatherObservation{observation}}, nil
+}
+
+// fetchWeatherData fetches weather data from the WeatherLink v2 API and caches it
+func fetchWeatherData() (weatherCurrent, error) {
+	stationID, err := discoverStationID()
+	if err != nil {
+		return weatherCurrent{}, fmt.Errorf("failed to discover station ID: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/current/%d?api-key=%s", api, stationID, key)
+
+	log.Printf("Making WeatherLink v2 API request to: %s", strings.Replace(url, key, "***REDACTED***", 1))
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return weatherCurrent{}, fmt.Errorf("error creating HTTP request: %v", err)
 	}
 	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-Api-Secret", apiSecret)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -210,11 +377,18 @@ func fetchWeatherData() (weatherCurrent, error) {
 		log.Printf("Raw API response: %s", string(bodyBytes))
 	}
 
-	var responseObject weatherCurrent
-	if err := json.Unmarshal(bodyBytes, &responseObject); err != nil {
+	var wlResponse wlCurrentResponse
+	if err := json.Unmarshal(bodyBytes, &wlResponse); err != nil {
 		log.Printf("Error unmarshaling JSON: %v", err)
 		log.Printf("Raw response that failed to unmarshal: %s", string(bodyBytes))
 		return weatherCurrent{}, fmt.Errorf("error parsing API response: %v", err)
+	}
+
+	log.Printf("Response for station ID %d contains %d sensors", wlResponse.StationID, len(wlResponse.Sensors))
+
+	responseObject, err := convertWLToLegacy(wlResponse)
+	if err != nil {
+		return weatherCurrent{}, err
 	}
 
 	log.Printf("Number of observations in response: %d", len(responseObject.Observations))
@@ -223,14 +397,12 @@ func fetchWeatherData() (weatherCurrent, error) {
 		return weatherCurrent{}, fmt.Errorf("no observations found in API response")
 	}
 
-	// Check if the returned data is fresh
 	obs := responseObject.Observations[0]
 	isFresh, obsTime, err := isDataFresh(obs.ObsTimeUtc)
 	if err != nil {
 		log.Printf("Warning: Could not determine data freshness: %v", err)
 	}
 
-	// Cache the data with observation time
 	cache.mu.Lock()
 	cache.data = responseObject
 	cache.lastFetched = time.Now()

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -23,22 +24,15 @@ var staticFiles embed.FS
 var templateFiles embed.FS
 
 type weatherObservation struct {
-	StationID         string      `json:"stationID"`
-	ObsTimeUtc        time.Time   `json:"obsTimeUtc"`
-	ObsTimeLocal      string      `json:"obsTimeLocal"`
-	Neighborhood      string      `json:"neighborhood"`
-	SoftwareType      string      `json:"softwareType"`
-	Country           string      `json:"country"`
-	SolarRadiation    float64     `json:"solarRadiation"`
-	Lon               float64     `json:"lon"`
-	RealtimeFrequency interface{} `json:"realtimeFrequency"`
-	Epoch             int         `json:"epoch"`
-	Lat               float64     `json:"lat"`
-	Uv                float64     `json:"uv"`
-	Winddir           int         `json:"winddir"`
-	Humidity          int         `json:"humidity"`
-	QcStatus          int         `json:"qcStatus"`
-	Imperial          struct {
+	StationID      string    `json:"stationID"`
+	ObsTimeUtc     time.Time `json:"obsTimeUtc"`
+	ObsTimeLocal   string    `json:"obsTimeLocal"`
+	SolarRadiation float64   `json:"solarRadiation"`
+	Epoch          int       `json:"epoch"`
+	Uv             float64   `json:"uv"`
+	Winddir        int       `json:"winddir"`
+	Humidity       int       `json:"humidity"`
+	Imperial       struct {
 		Temp        int     `json:"temp"`
 		HeatIndex   int     `json:"heatIndex"`
 		Dewpt       int     `json:"dewpt"`
@@ -177,6 +171,9 @@ func readRandomSecret() (string, error) {
 // isDataFresh checks if the observation data is reasonably current
 // With 30-minute fetch intervals, we accept data up to 35 minutes old
 func isDataFresh(obsTimeUtc time.Time) (bool, time.Time, error) {
+	if obsTimeUtc.IsZero() {
+		return false, obsTimeUtc, fmt.Errorf("observation timestamp is unset")
+	}
 	now := time.Now().UTC()
 	age := now.Sub(obsTimeUtc)
 	isFresh := age <= 35*time.Minute
@@ -334,8 +331,8 @@ func convertWLToLegacy(wl wlCurrentResponse) (weatherCurrent, error) {
 	observation.Imperial.HeatIndex = extractInt("heat_index")
 	observation.Imperial.Dewpt = extractInt("dew_point")
 	observation.Imperial.WindChill = extractInt("wind_chill")
-	observation.Imperial.WindSpeed = extractInt("wind_speed_last")
-	observation.Imperial.WindGust = extractInt("wind_speed_hi_last_2_min")
+	observation.Imperial.WindSpeed = int(math.Round(extractFloat("wind_speed_last")))
+	observation.Imperial.WindGust = int(math.Round(extractFloat("wind_speed_hi_last_2_min")))
 
 	if baroData != nil {
 		if v, ok := baroData["bar_sea_level"]; ok && v != nil {
@@ -396,12 +393,6 @@ func fetchWeatherData() (weatherCurrent, error) {
 	responseObject, err := convertWLToLegacy(wlResponse)
 	if err != nil {
 		return weatherCurrent{}, err
-	}
-
-	log.Printf("Number of observations in response: %d", len(responseObject.Observations))
-
-	if len(responseObject.Observations) == 0 {
-		return weatherCurrent{}, fmt.Errorf("no observations found in API response")
 	}
 
 	obs := responseObject.Observations[0]

--- a/main.go
+++ b/main.go
@@ -213,10 +213,17 @@ func shouldFetchNewData(t time.Time) bool {
 func discoverStationID() (int64, error) {
 	stationIDMutex.RLock()
 	if cachedStationID != 0 {
-		defer stationIDMutex.RUnlock()
-		return cachedStationID, nil
+		id := cachedStationID
+		stationIDMutex.RUnlock()
+		return id, nil
 	}
 	stationIDMutex.RUnlock()
+
+	stationIDMutex.Lock()
+	defer stationIDMutex.Unlock()
+	if cachedStationID != 0 {
+		return cachedStationID, nil
+	}
 
 	url := fmt.Sprintf("%s/stations?api-key=%s", api, key)
 
@@ -256,9 +263,7 @@ func discoverStationID() (int64, error) {
 		return 0, fmt.Errorf("no stations found for this API key")
 	}
 
-	stationIDMutex.Lock()
 	cachedStationID = stationsResp.Stations[0].StationID
-	stationIDMutex.Unlock()
 
 	log.Printf("Discovered station ID: %d (%s)", stationsResp.Stations[0].StationID, stationsResp.Stations[0].StationName)
 
@@ -297,7 +302,6 @@ func convertWLToLegacy(wl wlCurrentResponse) (weatherCurrent, error) {
 		return weatherCurrent{}, fmt.Errorf("missing or invalid timestamp in sensor data")
 	}
 	obsTime := time.Unix(int64(ts), 0).UTC()
-	obsTimeLocal := obsTime.Format("2006-01-02 15:04:05 MST")
 
 	extractFloat := func(key string) float64 {
 		if v, ok := issData[key]; ok && v != nil {
@@ -311,6 +315,9 @@ func convertWLToLegacy(wl wlCurrentResponse) (weatherCurrent, error) {
 	extractInt := func(key string) int {
 		return int(extractFloat(key))
 	}
+
+	tzOffsetSec := int(extractFloat("tz_offset"))
+	obsTimeLocal := time.Unix(int64(ts), 0).In(time.FixedZone("", tzOffsetSec)).Format("2006-01-02 15:04:05 -07:00")
 
 	observation := weatherObservation{
 		StationID:      fmt.Sprintf("%d", wl.StationID),
@@ -373,7 +380,7 @@ func fetchWeatherData() (weatherCurrent, error) {
 	}
 
 	log.Printf("API response body length: %d bytes", len(bodyBytes))
-	if len(bodyBytes) > 0 {
+	if _, ok := os.LookupEnv("DEBUG"); ok {
 		log.Printf("Raw API response: %s", string(bodyBytes))
 	}
 
@@ -462,6 +469,10 @@ func main() {
 		log.Fatal("Configuration error:", err)
 	}
 
+	if _, err := discoverStationID(); err != nil {
+		log.Fatal("Failed to discover station ID:", err)
+	}
+
 	// Debug printing of Environment
 	if _, ok := os.LookupEnv("DEBUG"); ok {
 		for _, element := range os.Environ() {
@@ -495,6 +506,12 @@ func main() {
 		responseObject, err := getCachedWeatherData()
 		if err != nil {
 			log.Printf("Error getting weather data: %v", err)
+			http.Error(w, "Weather data unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		if len(responseObject.Observations) == 0 {
+			log.Printf("No observations in weather data")
 			http.Error(w, "Weather data unavailable", http.StatusServiceUnavailable)
 			return
 		}

--- a/run-container.sh
+++ b/run-container.sh
@@ -80,7 +80,7 @@ load_envrc() {
         fi
 
         # Verify required environment variables are set
-        local required_vars=("API" "STATION_ID" "UNITS" "API_KEY" "RANDOM_SECRET")
+        local required_vars=("API" "KEY" "API_SECRET" "RANDOM_SECRET")
         local missing_vars=()
 
         for var in "${required_vars[@]}"; do
@@ -94,19 +94,17 @@ load_envrc() {
             printf '%s\n' "${missing_vars[@]}"
             echo ""
             echo "Please ensure your .envrc file contains all required variables:"
-            echo "  export API=\"https://api.weather.com/v2/pws/observations/current\""
-            echo "  export STATION_ID=\"YOUR_STATION_ID\""
-            echo "  export UNITS=\"e\""
-            echo "  export API_KEY=\"YOUR_API_KEY\""
+            echo "  export API=\"https://api.weatherlink.com/v2\""
+            echo "  export KEY=\"YOUR_WEATHERLINK_API_KEY\""
+            echo "  export API_SECRET=\"YOUR_WEATHERLINK_API_SECRET\""
             echo "  export RANDOM_SECRET=\"YOUR_RANDOM_SECRET\""
             exit 1
         fi
 
         echo -e "${GREEN}Environment variables loaded successfully:${NC}"
         echo "  API: ${API}"
-        echo "  STATION_ID: ${STATION_ID}"
-        echo "  UNITS: ${UNITS}"
-        echo "  API_KEY: [HIDDEN]"
+        echo "  KEY: [HIDDEN]"
+        echo "  API_SECRET: [HIDDEN]"
         echo "  RANDOM_SECRET: [HIDDEN]"
         echo ""
     else
@@ -218,13 +216,8 @@ if ! docker image inspect "$FULL_IMAGE" &> /dev/null; then
     echo -e "${YELLOW}Would you like to build it? (y/N)${NC}"
     read -r response
     if [[ "$response" =~ ^[Yy]$ ]]; then
-        if [[ -f "build-docker.sh" ]]; then
-            echo -e "${BLUE}Building image...${NC}"
-            ./build-docker.sh -n "$IMAGE_NAME" -t "$IMAGE_TAG"
-        else
-            echo -e "${RED}build-docker.sh not found. Please build the image manually.${NC}"
-            exit 1
-        fi
+        echo -e "${BLUE}Building image...${NC}"
+        task build-container
     else
         echo -e "${RED}Cannot run container without image. Exiting.${NC}"
         exit 1
@@ -255,9 +248,8 @@ DOCKER_CMD="$DOCKER_CMD -p $PORT:8080"
 
 # Add environment variables
 DOCKER_CMD="$DOCKER_CMD -e API=\"$API\""
-DOCKER_CMD="$DOCKER_CMD -e STATION_ID=\"$STATION_ID\""
-DOCKER_CMD="$DOCKER_CMD -e UNITS=\"$UNITS\""
-DOCKER_CMD="$DOCKER_CMD -e API_KEY=\"$API_KEY\""
+DOCKER_CMD="$DOCKER_CMD -e KEY=\"$KEY\""
+DOCKER_CMD="$DOCKER_CMD -e API_SECRET=\"$API_SECRET\""
 DOCKER_CMD="$DOCKER_CMD -e RANDOM_SECRET=\"$RANDOM_SECRET\""
 
 # Add debug flag if set


### PR DESCRIPTION
## Summary

- Replace Wunderground API integration with Davis Instruments WeatherLink v2 API (`GET /stations` for discovery, `GET /current/{stationID}` for data)
- Support both WeatherLink Console (sensor type 43/struct 23) and WeatherLink Live (sensor type 45/struct 10) station types
- Add env var fallback (`API`, `KEY`, `API_SECRET`, `RANDOM_SECRET`) so local dev works without `/mnt/secrets/` files
- Fix local report time to use `tz_offset` from sensor data instead of always rendering UTC
- Harden startup: station ID now discovered at launch and fails fast on bad key/network
- Fix TOCTOU race in station ID caching (double-checked locking); add panic guard in handler
- Round wind speed/gust to nearest int instead of truncating
- Remove dead code and 7 vestigial Wunderground struct fields
- Update `README.md`, `run-container.sh`, and `CLAUDE.md` to reflect WeatherLink v2

## Test Plan

- [x] Built clean (`go build -o pws .`)
- [x] Ran locally against live WeatherLink v2 API — HTTP 200, live data (station 176845 "Wild Sage Fields"), correct local time offset (`-06:00`)
- [x] Startup discovery logged correctly; bad-key scenario fails fast at launch
- [x] Raw API response only logged when `DEBUG` is set
- [x] `run-container.sh` validated env var names updated (`KEY`, `API_SECRET`)